### PR TITLE
🌍 Prefix routes with /fr for French localization

### DIFF
--- a/config/packages/sitemap.yaml
+++ b/config/packages/sitemap.yaml
@@ -4,4 +4,10 @@ presta_sitemap:
         changefreq: weekly
         lastmod: now
 
+    alternate:
+        enabled: true
+        default_locale: '%app.default_locale%'
+        locales: '%app.enabled_locales%'
+        i18n: symfony
+
     dump_directory: '%kernel.project_dir%/var/sitemaps'

--- a/config/packages/twig.yaml
+++ b/config/packages/twig.yaml
@@ -6,6 +6,8 @@ twig:
 
     globals:
         social_accounts: '%app.social_accounts%'
+        enabled_locales: '%app.enabled_locales%'
+        default_locale: '%app.default_locale%'
 
 when@test:
     twig:

--- a/config/routes/attributes.yaml
+++ b/config/routes/attributes.yaml
@@ -3,7 +3,9 @@ controllers_contact:
         path: ../../src/Contact/Ui/Controller
         namespace: App\Contact\Ui\Controller
     type: attribute
-    prefix: '/contact'
+    prefix:
+        en: '/contact'
+        fr: '/fr/contact'
     name_prefix: app_contact_
     trailing_slash_on_root: false
 

--- a/config/routes/resume.yaml
+++ b/config/routes/resume.yaml
@@ -3,6 +3,8 @@ website_resume_controllers:
         path: ../../src/Resume/Ui/Controller/Website
         namespace: App\Resume\Ui\Controller\Website
     type: attribute
-    prefix: '/cv'
+    prefix:
+        en: '/cv'
+        fr: '/fr/cv'
     name_prefix: app_website_resume_
     trailing_slash_on_root: false

--- a/config/routes/shared.yaml
+++ b/config/routes/shared.yaml
@@ -12,6 +12,8 @@ website_shared_controllers:
         path: ../../src/Shared/Ui/Controller/Website
         namespace: App\Shared\Ui\Controller\Website
     type: attribute
-    prefix: '/'
+    prefix:
+        en: ''
+        fr: '/fr'
     name_prefix: app_website_shared_
     trailing_slash_on_root: false

--- a/templates/app/base.html.twig
+++ b/templates/app/base.html.twig
@@ -55,10 +55,31 @@
             <script src="https://cdn.jsdelivr.net/npm/frankenphp-hot-reload/+esm" type="module"></script>
         {% endif %}
 
-        <link rel="icon"
-              href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 128 128%22><text y=%221.2em%22 font-size=%2296%22>🔮</text></svg>">
-        <link rel="canonical"
-              href="{% block meta_canonical app.current_route ? url(app.current_route, app.current_route_parameters) : '' %}" />
+        <link
+            rel="icon"
+            href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 128 128%22><text y=%221.2em%22 font-size=%2296%22>🔮</text></svg>"
+        />
+        <link
+            rel="canonical"
+            href="{% block meta_canonical app.current_route ? url(app.current_route, app.current_route_parameters) : '' %}"
+        />
+
+        {% block meta_hreflang %}
+            {% if app.current_route %}
+                {% for locale in enabled_locales %}
+                    <link
+                        rel="alternate"
+                        hreflang="{{ locale }}"
+                        href="{{ url(app.current_route, app.current_route_parameters|merge({_locale: locale})) }}"
+                    />
+                {% endfor %}
+                <link
+                    rel="alternate"
+                    hreflang="x-default"
+                    href="{{ url(app.current_route, app.current_route_parameters|merge({_locale: default_locale})) }}"
+                />
+            {% endif %}
+        {% endblock %}
     </head>
     <body class="bg-muted">
         {% block body %}{% endblock %}

--- a/templates/app/base_website.html.twig
+++ b/templates/app/base_website.html.twig
@@ -16,6 +16,20 @@
                         </a>
                     {% endfor %}
                 </div>
+                <ul class="flex items-center space-x-3 mt-8 md:mt-0 md:order-3 text-sm text-primary-foreground">
+                    {% for locale in enabled_locales %}
+                        <li>
+                            {% if locale == app.locale %}
+                                <span class="font-semibold uppercase">{{ locale }}</span>
+                            {% else %}
+                                <a href="{{ app.current_route
+                                    ? url(app.current_route, app.current_route_parameters|merge({_locale: locale}))
+                                    : url('app_website_shared_index', {_locale: locale}) }}"
+                                   class="uppercase hover:underline">{{ locale }}</a>
+                            {% endif %}
+                        </li>
+                    {% endfor %}
+                </ul>
                 <p class="mt-8 text-sm/6 text-primary-foreground md:order-1 md:mt-0">
                     {{ 'website.footer.copyright'|trans({year: 'now'|date('Y')}) }}
                 </p>

--- a/tests/Functional/WebsiteRouteTest.php
+++ b/tests/Functional/WebsiteRouteTest.php
@@ -19,10 +19,15 @@ final class WebsiteRouteTest extends RouteTestCase
     public static function urlsProvider(): iterable
     {
         yield 'GET /' => ['/', Request::METHOD_GET, SharedRouteNameEnum::WebsiteIndex];
+        yield 'GET /fr' => ['/fr', Request::METHOD_GET, SharedRouteNameEnum::WebsiteIndex];
 
         yield 'GET /cv' => ['/cv', Request::METHOD_GET, ResumeRouteNameEnum::WebsiteResume];
+        yield 'GET /fr/cv' => ['/fr/cv', Request::METHOD_GET, ResumeRouteNameEnum::WebsiteResume];
 
         yield 'GET /contact' => ['/contact', Request::METHOD_GET, ContactRouteNameEnum::WebsiteContact];
+        yield 'GET /fr/contact' => ['/fr/contact', Request::METHOD_GET, ContactRouteNameEnum::WebsiteContact];
+
         yield 'POST /contact' => ['/contact', Request::METHOD_POST, ContactRouteNameEnum::WebsiteContact];
+        yield 'POST /fr/contact' => ['/fr/contact', Request::METHOD_POST, ContactRouteNameEnum::WebsiteContact];
     }
 }


### PR DESCRIPTION
## Summary
- Apply Symfony's locale prefix map (`en: ''`, `fr: '/fr'`) on the public website route importers (`shared.yaml`, `resume.yaml`, `attributes.yaml`). Dashboard, login, robots.txt are untouched.
- Enable PrestaSitemap's built-in i18n alternates so `sitemap.*.xml` emits `<xhtml:link rel="alternate" hreflang="...">` for each localized public route.
- Add `<link rel="alternate" hreflang>` tags (+ `x-default`) in `templates/app/base.html.twig`, plus an EN/FR switcher in the website footer.
- Expose `enabled_locales` / `default_locale` as Twig globals.

Resulting URL map:

| Route | EN | FR |
| --- | --- | --- |
| Homepage | `/` | `/fr` |
| Resume | `/cv` | `/fr/cv` |
| Contact | `/contact` | `/fr/contact` |

## Test plan
- [x] `make test f=tests/Functional/WebsiteRouteTest.php` — 8 cases (EN + FR variants of `/`, `/cv`, `/contact`)
- [x] `make test f=tests/Functional/DashboardRouteTest.php` — no regression on unprefixed admin routes
- [x] `make test-integration`
- [x] `make phpstan` (level 8) / `make phpcsfixer` / `make twigcsfixer`
- [x] `bin/console debug:router` shows `.en` / `.fr` variants for the three public routes
- [x] `presta:sitemaps:dump` emits hreflang alternates in `sitemap.homepage.xml` and `sitemap.default.xml`
- [ ] Manual browser smoke: visit `/` and `/fr`, check `<html lang>`, hreflang link tags, footer switcher round-trip, contact form submit in both locales