### PR TITLE
📝 Update README, AGENTS, CLAUDE for recent changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,11 +4,11 @@ Welcome, AI assistant. Please follow these guidelines when contributing to this 
 
 ## Project Overview
 
-Tales From a Dev is a portfolio website built with **Symfony 7.4** and **PHP 8.5+**, following **Domain-Driven Design (DDD)** principles with a layered architecture.
+Tales From a Dev is a portfolio website built with **Symfony 8.1** and **PHP 8.5+**, following **Domain-Driven Design (DDD)** principles with a layered architecture. The site is bilingual (English / French) with locale-prefixed routes and ships SEO primitives (sitemap, JSON-LD, robots).
 
 ## Stack
 
-- **Backend**: PHP 8.5 / Symfony 7.4 / Doctrine ORM 3.5
+- **Backend**: PHP 8.5 / Symfony 8.1 / Doctrine ORM 3.5
 - **Frontend**: Tailwind CSS 4.3 / Stimulus / Symfony AssetMapper / Twig Components / Turbo
 - **Server**: FrankenPHP (Caddy-based, with Mercure built in)
 - **Database**: PostgreSQL 17
@@ -58,19 +58,34 @@ The app uses a **modular DDD structure** — each domain is self-contained under
 
 | Module | Purpose |
 |--------|---------|
-| `Analytics/` | Page view tracking |
+| `Analytics/` | Page view tracking + dynamic `robots.txt` |
 | `Contact/` | Contact form + email |
-| `Experience/` | Portfolio / experience entries |
+| `Experience/` | Portfolio / experience entries (timeline) |
 | `GitHub/` | GitHub API sync |
+| `Resume/` | CV page (served under `/cv` and `/fr/cv`) |
 | `Settings/` | Site settings |
 | `User/` | Authentication |
-| `Shared/` | Value objects, base classes, shared interfaces |
+| `Shared/` | Value objects, base classes, shared interfaces, SEO (JSON-LD encoder, structured data builders) |
 
 Each module has its own services registered in `config/services/<module>.yaml` and routes in `config/routes/`.
 
-Templates live in `templates/` with a parallel structure: `component/` for Twig Components, `app/` for page templates.
+Templates live in `templates/` with a parallel structure: `component/` for Twig Components, `app/` for page templates. Page templates are grouped per module (e.g. `templates/app/website/contact/index.html.twig`, `templates/app/website/shared/index.html.twig`).
 
 Tests mirror this structure under `tests/Unit/`, `tests/Integration/`, and `tests/Functional/`.
+
+## Internationalization
+
+- Default locale: `en`. Enabled locales: `en`, `fr` (see `app.default_locale` / `app.enabled_locales` in `config/services.yaml`).
+- Website routes are declared per-locale with French prefixed by `/fr` (e.g. `/contact` ↔ `/fr/contact`, `/cv` ↔ `/fr/cv`). Dashboard routes stay locale-agnostic.
+- `base.html.twig` emits `hreflang` alternates (including `x-default`) for every enabled locale on the current route.
+- All user-facing strings go through `|trans`; translations live under `translations/{en,fr}/`.
+
+## SEO
+
+- `PrestaSitemapBundle` exposes the XML sitemap (`presta:sitemaps:dump` / `PrestaSitemapBundle_index` route). Alternate locales are emitted via `alternate.i18n: symfony`.
+- `App\Analytics\Ui\Controller\Website\RobotController` serves `/robots.txt` and links the sitemap absolute URL.
+- `App\Shared\Infrastructure\Seo\HomepageStructuredDataBuilder` produces the homepage `Person` JSON-LD; rendered in `base.html.twig` via the `meta_jsonld` block.
+- `App\Shared\Infrastructure\Serializer\Encoder\JsonLdEncoder` registers the `jsonld` format with the Symfony Serializer (HTML-safe encoding flags).
 
 ## PHP Code Standards
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,6 +84,10 @@ Each module is split into:
 
 **Ui layer** controllers use `renderBlock()` for Turbo Stream responses and fall back to redirects for plain requests, checking against `TurboBundle::STREAM_FORMAT`.
 
+**Localization.** Default locale `en`, enabled locales `en` + `fr` (see `config/services.yaml`). Website routes are declared per-locale in `config/routes/*.yaml` with French prefixed by `/fr` (e.g. `/contact` ↔ `/fr/contact`, `/cv` ↔ `/fr/cv`); dashboard routes stay locale-agnostic. All user-facing text goes through `|trans` — translations live under `translations/{en,fr}/`. `base.html.twig` emits `hreflang` alternates including `x-default` for every enabled locale.
+
+**SEO.** `PrestaSitemapBundle` exposes the XML sitemap (alternates configured via `alternate.i18n: symfony` in `config/packages/sitemap.yaml`). `App\Analytics\Ui\Controller\Website\RobotController` serves `/robots.txt`. JSON-LD structured data is built by `App\Shared\Infrastructure\Seo\HomepageStructuredDataBuilder` and serialized through `App\Shared\Infrastructure\Serializer\Encoder\JsonLdEncoder` (registered with format `jsonld`, HTML-safe flags). Templates render it via the `meta_jsonld` block in `base.html.twig`.
+
 ## Test organization
 
 - `tests/Unit/` — Pure PHPUnit, no container. Mirror `src/` namespace structure.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Build](https://img.shields.io/github/actions/workflow/status/tales-from-a-dev/website/ci.yaml?style=for-the-badge)](https://github.com/tales-from-a-dev/website/actions/workflows/ci.yml)
 ![PHP Version](https://img.shields.io/badge/php-8.5-4f5b93.svg?style=for-the-badge)
-![Symfony Version](https://img.shields.io/badge/symfony-7.4-000.svg?style=for-the-badge)
+![Symfony Version](https://img.shields.io/badge/symfony-8.1-000.svg?style=for-the-badge)
 ![Tailwind Version](https://img.shields.io/badge/tailwind-4.3-00bcff.svg?style=for-the-badge)
 ![PostgreSQL Version](https://img.shields.io/badge/postgresql-17-6395be.svg?style=for-the-badge)
 
@@ -10,10 +10,12 @@ A personal website built with Symfony showcasing development experiences, projec
 
 ## 📋 Overview
 
-This is a modern web application built with Symfony 7.4 and PHP 8.5, featuring:
-- **Modular Architecture**: Organized into domain modules (Analytics, Contact, Experience, GitHub, Settings, User)
+This is a modern web application built with Symfony 8.1 and PHP 8.5, featuring:
+- **Modular Architecture**: Organized into domain modules (Analytics, Contact, Experience, GitHub, Resume, Settings, User)
+- **Internationalization**: English (default) and French, with locale-prefixed routes (`/fr/...`)
+- **SEO**: XML sitemap (PrestaSitemapBundle), JSON-LD structured data, dynamic `robots.txt`, hreflang alternate links
 - **Real-time Features**: Mercure integration for live updates
-- **Modern Frontend**: Tailwind CSS 4.1 with Symfony AssetMapper and Stimulus
+- **Modern Frontend**: Tailwind CSS 4.3 with Symfony AssetMapper and Stimulus
 - **Message Queue**: Symfony Messenger with Doctrine transport
 - **Caching**: Valkey (Redis-compatible) for application cache
 - **Database**: PostgreSQL 17 with Doctrine ORM
@@ -23,13 +25,13 @@ This is a modern web application built with Symfony 7.4 and PHP 8.5, featuring:
 
 ### Backend
 - **Language**: PHP 8.5
-- **Framework**: Symfony 7.4
+- **Framework**: Symfony 8.1
 - **ORM**: Doctrine ORM 3.5
 - **Server**: FrankenPHP
 - **Package Manager**: Composer
 
 ### Frontend
-- **CSS Framework**: Tailwind CSS 4.2
+- **CSS Framework**: Tailwind CSS 4.3
 - **JavaScript**: Stimulus (via Symfony UX)
 - **Asset Management**: Symfony AssetMapper
 - **Components**: Twig Components, Turbo
@@ -276,13 +278,14 @@ make coverage
 ├── public/              # Web root
 │   └── index.php        # Application entry point
 ├── src/                 # Application source code
-│   ├── Analytics/       # Analytics module
-│   ├── Contact/         # Contact module
-│   ├── Experience/      # Experience module
+│   ├── Analytics/       # Page view tracking + robots.txt
+│   ├── Contact/         # Contact form
+│   ├── Experience/      # Professional timeline
 │   ├── GitHub/          # GitHub integration module
-│   ├── Settings/        # Settings module
-│   ├── Shared/          # Shared/common code
-│   └── User/            # User module
+│   ├── Resume/          # CV page
+│   ├── Settings/        # Application settings
+│   ├── Shared/          # Shared/common code (SEO, kernel, base entities)
+│   └── User/            # Authentication and user management
 ├── templates/           # Twig templates
 ├── tests/               # Test files
 │   ├── Fixtures/        # Test fixtures


### PR DESCRIPTION
## Summary
- Bump Symfony references from 7.4 to 8.1 (badge, overview, stack)
- Add the `Resume` module to the module lists; refresh the `Shared` description to mention SEO helpers
- Document i18n (default `en`, enabled `en`+`fr`, `/fr`-prefixed website routes, `hreflang` alternates) and SEO (PrestaSitemapBundle, `RobotController`, `HomepageStructuredDataBuilder`, `JsonLdEncoder`)

## Test plan
- [ ] Render the README on GitHub and confirm badges, module list and Tailwind version (4.3) display correctly
- [ ] Skim AGENTS.md and CLAUDE.md for the new Localization / SEO sections