### PR TITLE
⚡️ Self-host Inter font and move JSON-LD to body end

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -4,7 +4,6 @@
  * This file will be included onto the page via the importmap() Twig function,
  * which should already be in your base.html.twig.
  */
-import '@fontsource-variable/inter/index.min.css'
 import './styles/app.css';
 
 import './stimulus_bootstrap.js';

--- a/assets/styles/app.css
+++ b/assets/styles/app.css
@@ -9,6 +9,30 @@
 @source not "../../public";
 
 /*
+ * Fonts
+ */
+
+@font-face {
+    font-family: "Inter Variable";
+    font-style: normal;
+    font-display: swap;
+    font-weight: 100 900;
+    src: url("../vendor/@fontsource-variable/inter/files/inter-latin-wght-normal.woff2") format("woff2-variations");
+    unicode-range:
+        U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+
+@font-face {
+    font-family: "Inter Variable";
+    font-style: normal;
+    font-display: swap;
+    font-weight: 100 900;
+    src: url("../vendor/@fontsource-variable/inter/files/inter-latin-ext-wght-normal.woff2") format("woff2-variations");
+    unicode-range:
+        U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
+}
+
+/*
  * Variant
  */
 

--- a/templates/app/base.html.twig
+++ b/templates/app/base.html.twig
@@ -26,8 +26,6 @@
             {% block meta_og_image %}{% endblock %}
         {% endblock %}
 
-        {% block meta_jsonld %}{% endblock %}
-
         <title>{% block meta_title %}{{ 'app.meta.title'|trans }}{% endblock %}</title>
 
         {% block fonts %}
@@ -61,7 +59,7 @@
         />
         <link
             rel="canonical"
-            href="{% block meta_canonical app.current_route ? url(app.current_route, app.current_route_parameters) : '' %}"
+            href="{% block meta_canonical app.current_route ? url(app.current_route, app.current_route_parameters) : absolute_url('/') %}"
         />
 
         {% block meta_hreflang %}
@@ -83,5 +81,10 @@
     </head>
     <body class="bg-muted">
         {% block body %}{% endblock %}
+        {% if block('meta_jsonld') %}
+            <script type="application/ld+json">
+              {%- block meta_jsonld %}{% endblock -%}
+            </script>
+        {% endif %}
     </body>
 </html>

--- a/templates/app/website/shared/index.html.twig
+++ b/templates/app/website/shared/index.html.twig
@@ -11,7 +11,7 @@
 {% endblock %}
 
 {% block meta_jsonld %}
-    <script type="application/ld+json">{{ structured_data|serialize('jsonld')|raw }}</script>
+    {{ structured_data|serialize('jsonld')|raw }}
 {% endblock %}
 
 {% block main %}


### PR DESCRIPTION
## Summary

- Drop the `@fontsource-variable/inter` JS import and declare the two `@font-face` rules (latin + latin-ext) directly in `app.css`, pointing at the already-preloaded self-hosted woff2 files. This removes a render-blocking CSS import that duplicated the fonts the `fonts` block preloads.
- Move the `meta_jsonld` block out of `<head>` and render it at the end of `<body>`, wrapped in a single `<script type="application/ld+json">` guarded by `{% if block('meta_jsonld') %}` so pages without structured data emit nothing.
- Templates now provide only the JSON payload for `meta_jsonld` — the `<script>` tag lives in `base.html.twig`.
- Give `meta_canonical` a real fallback (`absolute_url('/')`) instead of an empty `href` when there is no current route.

## Test plan

- [x] `make asset-build` then check Inter still renders and the woff2 files are requested once
- [x] View source on `/` and `/fr`: single `<script type="application/ld+json">` at the end of `<body>`, valid JSON
- [x] View source on a page without structured data (e.g. `/contact`): no empty `ld+json` script
- [x] `<link rel="canonical">` never has an empty `href`
- [x] `make test`